### PR TITLE
enable ansible lifecycle driver to work on OCP 4.4+

### DIFF
--- a/helm/ansiblelifecycledriver/templates/deployment.yaml
+++ b/helm/ansiblelifecycledriver/templates/deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ansible-lifecycle-driver
 spec:
   replicas: {{ .Values.app.replicas }}
+  selector:
+    matchLabels:
+      app: ansible-lifecycle-driver  
   template:
     metadata:
       labels:


### PR DESCRIPTION
enable the installation of driver on newer OCP versions by updating apiVersion in deployment #87 