### PR TITLE
Issue 197 - Vulnerability : wheel - CVE-2022-40898 - High

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,7 @@ setup(
         'boto==2.49.0',
         'boto3==1.18.42',
         'botocore==1.21.42',
-        'itsdangerous==2.0.1',
-        'azure-ansible-base==1.0.0'
+        'itsdangerous==2.0.1'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
# Pull Request Review

## Checklist

- [x] **Issue** : https://github.com/IBM/ansible-lifecycle-driver/issues/197
- [x] **List of related PRs** : N.A.
- [x] **Project builds without any errors**
- [x] **Unit Tests** : All passed
- [x] **Ran manual functional “smoke” test (does product as a whole still work?)** 
- [x] **User Story meets the acceptance criteria and passes**
- [x]  **Description of the changes**:  Fix Vulnerability : wheel - CVE-2022-40898 - High
There is one library azure-ansible-base==1.0.0 which was added previously as per MCNP team's request. That is causing this vulnerability. This library is no longer needed as per confirmation we have received from MCNP team. So we are removing it and it will resolve the vulnerability as well.