### PR TITLE
updated kubectl version to fix go library vulnerabilities

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN addgroup -S ald \
  && ansible-galaxy collection install ansible.utils -f -p /usr/local/lib/python3.10/site-packages/ansible_collections \
  && pip install netaddr \
  && apk del .build-deps gcc musl-dev libffi-dev openssl-dev python3-dev make git \
- && curl -L https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
+ && curl -L https://storage.googleapis.com/kubernetes-release/release/v1.26.3/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
  && chmod +x /usr/local/bin/kubectl
 
 COPY --chown=ald:0 ansible.cfg /etc/ansible/ansible.cfg


### PR DESCRIPTION
- [X] **Issue** : Fix vulnerabilities  #207
- [X] **List of related PRs**  : N/A
- [X] **Project builds without any errors**  : N/A
- [X] **Unit Tests**  : N/A
- [X]  **Ran manual functional “smoke” test (does product as a whole still work?)**  N/A
- [X]  **User Story meets the acceptance criteria and passes**
- [X]  **Description of the changes:**
   1. updated kubectl version to 1.26.3 in the Dockerfile to fix go library vulnerabilities.
   2. base image(3.10-alpine) has also updated in GitHub to fix os and python library vulnerabilities. No need to change anything in the Dockerfile but when the image is built for release, it should fix all os and python vulnerabilities.