### PR TITLE
Fix Helm versioning to use semver

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-String tarquinBranch = "develop"
+String tarquinBranch = "CPNA-1189"
 
 library "tarquin@$tarquinBranch"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-String tarquinBranch = "CPNA-1189"
+String tarquinBranch = "develop"
 
 library "tarquin@$tarquinBranch"
 

--- a/build.py
+++ b/build.py
@@ -102,6 +102,7 @@ class Builder:
         self.stages = []
         self.project_version = None
         self.py_normalized_version = None
+        self.helm_normalized_version = None
 
     def report(self):
         print('================================================')
@@ -156,7 +157,7 @@ class Builder:
   
     def build(self):
         self.init_artifacts_directory()
-        self.run_unit_tests()
+        # self.run_unit_tests()
         self.build_python_wheel()
         self.pkg_docs()
         if args.skip_docker is not True:
@@ -214,6 +215,10 @@ class Builder:
                 self.py_normalized_version = self.py_normalized_version.replace('-alpha-', 'a')
                 self.py_normalized_version = self.py_normalized_version.replace('-beta-', 'b')
                 self.py_normalized_version = self.py_normalized_version.replace('-rc', 'rc')
+                self.helm_normalized_version = self.py_normalized_version.replace('a', '-alpha.')
+                self.helm_normalized_version = self.py_normalized_version.replace('b', '-beta.')
+                self.helm_normalized_version = self.py_normalized_version.replace('rc', '-rc.')
+                self.helm_normalized_version = self.py_normalized_version.replace('.dev', '-dev.')
 
     def run_unit_tests(self):
         with self.stage('Run Unit Tests') as s:
@@ -261,7 +266,7 @@ class Builder:
             helm_chart_path = os.path.join(self.project_path, HELM_CHART_PATH)
             template_loader = jinja.FileSystemLoader(searchpath=helm_chart_path)
             template_env = jinja.Environment(variable_start_string='${', variable_end_string='}', loader=template_loader)
-            resolvable_props = {'version': self.project_version}
+            resolvable_props = {'version': self.helm_normalized_version}
             for item in os.listdir(helm_chart_path):
                 full_item_path = os.path.join(helm_chart_path, item)
                 if os.path.isdir(full_item_path):

--- a/build.py
+++ b/build.py
@@ -157,7 +157,7 @@ class Builder:
   
     def build(self):
         self.init_artifacts_directory()
-        # self.run_unit_tests()
+        self.run_unit_tests()
         self.build_python_wheel()
         self.pkg_docs()
         if args.skip_docker is not True:

--- a/build.py
+++ b/build.py
@@ -214,7 +214,7 @@ class Builder:
                 self.py_normalized_version = self.py_normalized_version.replace('-alpha-', 'a')
                 self.py_normalized_version = self.py_normalized_version.replace('-beta-', 'b')
                 self.py_normalized_version = self.py_normalized_version.replace('-rc-', 'rc')
-                self.py_normalized_version = self.py_normalized_version.replace('-dev-', '.dev0')
+                self.py_normalized_version = self.py_normalized_version.replace('-dev-', '.dev')
 
     def run_unit_tests(self):
         with self.stage('Run Unit Tests') as s:

--- a/build.py
+++ b/build.py
@@ -102,7 +102,6 @@ class Builder:
         self.stages = []
         self.project_version = None
         self.py_normalized_version = None
-        self.helm_normalized_version = None
 
     def report(self):
         print('================================================')
@@ -214,11 +213,8 @@ class Builder:
                 self.py_normalized_version = pkg_info_data['version']
                 self.py_normalized_version = self.py_normalized_version.replace('-alpha-', 'a')
                 self.py_normalized_version = self.py_normalized_version.replace('-beta-', 'b')
-                self.py_normalized_version = self.py_normalized_version.replace('-rc', 'rc')
-                self.helm_normalized_version = self.py_normalized_version.replace('a', '-alpha.')
-                self.helm_normalized_version = self.py_normalized_version.replace('b', '-beta.')
-                self.helm_normalized_version = self.py_normalized_version.replace('rc', '-rc.')
-                self.helm_normalized_version = self.py_normalized_version.replace('.dev', '-dev.')
+                self.py_normalized_version = self.py_normalized_version.replace('-rc-', 'rc')
+                self.py_normalized_version = self.py_normalized_version.replace('-dev-', '.dev0')
 
     def run_unit_tests(self):
         with self.stage('Run Unit Tests') as s:
@@ -266,7 +262,7 @@ class Builder:
             helm_chart_path = os.path.join(self.project_path, HELM_CHART_PATH)
             template_loader = jinja.FileSystemLoader(searchpath=helm_chart_path)
             template_env = jinja.Environment(variable_start_string='${', variable_end_string='}', loader=template_loader)
-            resolvable_props = {'version': self.helm_normalized_version}
+            resolvable_props = {'version': self.project_version}
             for item in os.listdir(helm_chart_path):
                 full_item_path = os.path.join(helm_chart_path, item)
                 if os.path.isdir(full_item_path):

--- a/build.py
+++ b/build.py
@@ -213,7 +213,7 @@ class Builder:
                 self.py_normalized_version = pkg_info_data['version']
                 self.py_normalized_version = self.py_normalized_version.replace('-alpha-', 'a')
                 self.py_normalized_version = self.py_normalized_version.replace('-beta-', 'b')
-                self.py_normalized_version = self.py_normalized_version.replace('-rc-', 'rc')
+                self.py_normalized_version = self.py_normalized_version.replace('-rc', 'rc')
                 self.py_normalized_version = self.py_normalized_version.replace('-dev-', '.dev')
 
     def run_unit_tests(self):


### PR DESCRIPTION
Fix Helm versioning to use semver

Validation error when in helm 3 if version is not semver.

Merge after pipeline changes.